### PR TITLE
Update users API endpoint to accept contact name and email

### DIFF
--- a/aunty_api/blueprints/contacts/views.py
+++ b/aunty_api/blueprints/contacts/views.py
@@ -39,9 +39,7 @@ def create():
             req_data = request.get_json()
             req_data['name']
             req_data['email']
-            req_data['location']
-            req_data['relationship']
-            contact = PersonalContact(name=req_data['name'], email=req_data['email'], relationship=req_data['relationship'], location=req_data['location'], user=user)
+            contact = PersonalContact(name=req_data['name'], email=req_data['email'], user=user)
             
             if contact.save():
                 return jsonify([{
@@ -50,9 +48,7 @@ def create():
                     'contact': {
                         'id': contact.id,
                         'name': contact.name,
-                        'location': contact.location,
-                        'email': contact.email,
-                        'relationship': contact.relationship
+                        'email': contact.email
                     }
                 }])
             else:

--- a/aunty_api/blueprints/users/views.py
+++ b/aunty_api/blueprints/users/views.py
@@ -15,24 +15,35 @@ def create():
     email = req_data['email']
     date_of_birth = req_data['dateOfBirth']
     nationality = req_data['nationality']
+    contact_name = req_data['contactName']
+    contact_email = req_data['contactEmail']
     hashed_password = generate_password_hash(req_data['password'])
     
     user = User(first_name=first_name, last_name=last_name, email=email, password=hashed_password, dob=date_of_birth, nationality=nationality)
 
     if user.save():
         token = encode_auth_token(user)
-        return jsonify({
-            'auth_token': token,
-            'message': 'Successfully created the account. Please log in.',
-            'status': 'success',
-            'user': {
-                'id': user.id,
-                'first_name': user.first_name,
-                'last_name': user.last_name,
-                'email': user.email
-            }
-        })
-    else:
+        contact = PersonalContact(
+            user=user, name=contact_name, email=contact_email)
+        if contact.save():
+            return jsonify({
+                'auth_token': token,
+                'message': 'Successfully created the account. Please log in.',
+                'status': 'success',
+                'user': {
+                    'id': user.id,
+                    'first_name': user.first_name,
+                    'last_name': user.last_name,
+                    'email': user.email
+                }
+            })
+        else:
+            errors = contact.errors
+            return jsonify({
+                'status': 'failed',
+                'message': errors
+            })
+    elif user.errors:
         errors = user.errors
         return jsonify({
             'status': 'failed',

--- a/models/personal_contact.py
+++ b/models/personal_contact.py
@@ -5,8 +5,8 @@ import peewee as pw
 class PersonalContact(BaseModel):
     user = pw.ForeignKeyField(User, backref="contacts")
     name = pw.CharField()
-    relationship = pw.CharField()
-    location = pw.BooleanField() # 0 = Local, 1 = Foreign
-    priority = pw.IntegerField() # allow users to save up to 5 contacts & rank them by priority
+    relationship = pw.CharField(null=True)
+    location = pw.BooleanField(null=True) # 0 = Local, 1 = Foreign
+    priority = pw.IntegerField(null=True) # allow users to save up to 5 contacts & rank them by priority
     email = pw.CharField()
-    phone_number = pw.CharField()
+    phone_number = pw.CharField(null=True)


### PR DESCRIPTION
- Updated create user view in order to create a personal contact with only name and email.
- Note that I've added null=True on all unrequired fields so a migration is necessary.